### PR TITLE
Update FileCopyManager.cpp

### DIFF
--- a/src/src/helper/FileCopyManager.cpp
+++ b/src/src/helper/FileCopyManager.cpp
@@ -1,4 +1,4 @@
-#include "filecopymanager.h"
+#include "FileCopyManager.h"
 #include "filecopyworker.h"
 #include <QThread>
 #include <QDebug>


### PR DESCRIPTION
Fix Linux build error caused by case-sensitive include

On Linux (Ubuntu 22.04), the build fails with:

    fatal error: filecopymanager.h: No such file or directory

The actual header file in the project is:

    src/src/helper/FileCopyManager.h

Linux filesystems are case-sensitive, so the include directive must be:

    #include "FileCopyManager.h"

Instead of:

    #include "filecopymanager.h"

This PR updates the include statement to use the correct casing and resolves the Linux build failure.

修正在 Ubuntu22.04 遇到大小寫編譯失敗問題